### PR TITLE
fix: rename app for debugging and add better logging

### DIFF
--- a/green_app/app.json
+++ b/green_app/app.json
@@ -1,9 +1,9 @@
 {
-  "name": "external-pdf-importer",
+  "name": "green-app-debug",
   "type": "web",
-  "version": "2024.07.11.12.52.53",
-  "display_name": "Green App",
-  "description": "External PDF Importer",
+  "version": "2024.08.09.1723212525877",
+  "display_name": "Green App Debug",
+  "description": "Green App Debug",
   "displayName": "",
   "icon": "fas fa-music",
   "module": {

--- a/green_app/index.js
+++ b/green_app/index.js
@@ -18,16 +18,14 @@ document.addEventListener('DOMContentLoaded', function () {
     generateButton.disabled = true
     loadingIndicator.classList.remove('hidden')
 
-    fetch(localStorage.greenAppLocalBackend
-      ? 'http://localhost:3123/'
-      : 'https://analytics.pitcher.com/test/green_helloworld/generate_pdf.php', {
+    fetch('http://localhost:3123/', {
       method: 'POST',
       body: new URLSearchParams({
         userName,
         clientName,
         token: window.env.pitcher.access_token,
         instanceId: window.env.pitcher.instance.id,
-        folderId: '01J1N752B5W1JTS87721R6VSKW',
+        folderId: '01J4VQDME5ZB0PWC7VZ1VVSMTV',
       }),
     })
       .then((response) => response.text())

--- a/green_app_backend/index.js
+++ b/green_app_backend/index.js
@@ -150,7 +150,7 @@ app.post('/', async (req, res) => {
       res.status(400).send('Invalid input.')
     }
   } catch (error) {
-    console.error('Error processing request:', error)
+    console.error('Error processing request:', error.response ? error.response.data : error.message)
     res.status(500).send('Internal server error.')
   }
 })


### PR DESCRIPTION
### 📖 Steps

1. checkout this branch
2. start `green_app_backend` with `npm start`
3. go to dev in Vontobel instance (not admin because it does not have access to the CRM data, rep side -- notice the url in the video)
4. add Green App Debug to one of your pitchdeck like in the videos. 
5. use green app generator -- you should see an incoming request on your local machine
6. created files should now be at https://dev.my.pitcher.com/browser/content/01J4VQDME5ZB0PWC7VZ1VVSMTV


### 📷 Video
[green-app-debug.webm](https://github.com/user-attachments/assets/3f4ed06a-b42a-4b23-8f06-3d13abd4afb3)

